### PR TITLE
feat: Implement modern landing page and refactor to Astro/Sanity

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,13 +6,14 @@ import react from "@astrojs/react";
 
 // https://astro.build/config
 export default defineConfig({
+  output: 'static',
   integrations: [
     sanity({
       projectId: 'jav1zi17',
       dataset: 'production',
       useCdn: false, // See note on using the CDN
       apiVersion: "2025-01-28", // insert the current date to access the latest version of the API
-      studioBasePath: '/studio' // If you want to access the Studio on a route
+      // studioBasePath: '/studio' // If you want to access the Studio on a route
     }),
     react(),
   ],

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const NavContainer = styled.nav`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  padding: 1.5rem 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #fff;
+  font-family: 'Inter', sans-serif;
+`;
+
+const Logo = styled.a`
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #fff;
+  text-decoration: none;
+`;
+
+const NavLinks = styled.div<{ isOpen: boolean }>`
+  display: flex;
+  gap: 2rem;
+
+  @media (max-width: 768px) {
+    display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
+    flex-direction: column;
+    position: absolute;
+    top: 80px;
+    left: 0;
+    right: 0;
+    background-color: rgba(26, 32, 44, 0.9);
+    padding: 2rem;
+    text-align: center;
+  }
+`;
+
+const NavLink = styled.a`
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.3s ease;
+
+  &:hover {
+    color: #3B82F6;
+  }
+`;
+
+const Hamburger = styled.div`
+  display: none;
+  cursor: pointer;
+
+  @media (max-width: 768px) {
+    display: block;
+  }
+
+  div {
+    width: 25px;
+    height: 3px;
+    background-color: white;
+    margin: 5px;
+    transition: all 0.3s ease;
+  }
+`;
+
+
+const Navigation: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <NavContainer>
+      <Logo href="/">Urban Pixels</Logo>
+      <Hamburger onClick={() => setIsOpen(!isOpen)}>
+        <div />
+        <div />
+        <div />
+      </Hamburger>
+      <NavLinks isOpen={isOpen}>
+        <NavLink href="/">Home</NavLink>
+        <NavLink href="/photos">Gallery</NavLink>
+      </NavLinks>
+    </NavContainer>
+  );
+};
+
+export default Navigation;

--- a/src/components/PhotoGrid.tsx
+++ b/src/components/PhotoGrid.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react';
+import type { SanityDocument } from '@sanity/client';
+import { loadQuery } from '../sanity/lib/load-query';
+import { urlForImage } from '../sanity/lib/url-for-image';
+import styled from 'styled-components';
+
+interface PhotoGridProps {
+  filter?: 'featured' | 'all';
+  category?: string;
+}
+
+const GridContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 2rem;
+  padding: 0 2.5rem;
+`;
+
+const PhotoCard = styled.a`
+  text-decoration: none;
+  color: #1a202c;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+  &:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  }
+`;
+
+const CardImageContainer = styled.div`
+  overflow: hidden;
+  aspect-ratio: 1 / 1;
+  background-color: #f8f9fa;
+`;
+
+const CardImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const PhotoGrid: React.FC<PhotoGridProps> = ({ filter = 'all', category }) => {
+  const [photos, setPhotos] = useState<SanityDocument[]>([]);
+
+  useEffect(() => {
+    let query = `*[_type == "photo"]`;
+    const params: { [key: string]: any } = {};
+
+    if (filter === 'featured') {
+      query += `[featured == true]`;
+    }
+
+    if (category) {
+      query += `[count((categories[]->title)[@ in [$category]]) > 0]`;
+      params.category = category;
+    }
+
+    query += ` | order(dateTaken desc)`;
+
+    const fetchPhotos = async () => {
+      const { data } = await loadQuery<SanityDocument[]>(query, params);
+      setPhotos(data);
+    };
+
+    fetchPhotos();
+  }, [filter, category]);
+
+  return (
+    <GridContainer>
+      {photos.map((photo) => (
+        <PhotoCard key={photo._id} href={`/photo/${photo.slug.current}`}>
+          {photo.image && (
+            <CardImageContainer>
+              <CardImage
+                src={urlForImage(photo.image).width(600).height(600).fit('crop').quality(80).url()}
+                alt={photo.image.alt || ""}
+              />
+            </CardImageContainer>
+          )}
+        </PhotoCard>
+      ))}
+    </GridContainer>
+  );
+};
+
+export default PhotoGrid;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,3 +1,6 @@
+---
+import Navigation from '../components/Navigation.tsx';
+---
 <!doctype html>
 <html lang="en">
 	<head>
@@ -6,8 +9,12 @@
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro Basics</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 	</head>
 	<body>
+		<Navigation client:only="react" />
 		<slot />
 	</body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,116 +1,265 @@
 ---
-import type { SanityDocument } from "@sanity/client";
-import { urlForImage } from "../sanity/lib/url-for-image";
-import { loadQuery } from "../sanity/lib/load-query";
-import Layout from "../layouts/Layout.astro";
+import Layout from '../layouts/Layout.astro';
+import PhotoGrid from '../components/PhotoGrid.tsx';
+import { loadQuery } from '../sanity/lib/load-query';
+import type { SanityDocument } from '@sanity/client';
+import { urlForImage } from '../sanity/lib/url-for-image';
 
-const { data: posts } = await loadQuery<SanityDocument[]>({
-  query: `*[_type == "post" && defined(slug.current)] | order(publishedAt desc)`,
-});
+const { data: heroPhoto } = await loadQuery<SanityDocument | null>(`*[_type == "photo" && featured == true] | order(_createdAt desc)[0]`);
+const { data: categories } = await loadQuery<SanityDocument[]>(`*[_type == "category"] | order(title asc)`);
 ---
 
-<Layout title="Urban Pixels">
-  <main class="main-content">
-    <header class="page-header">
-      <h1 class="page-title">Urban Pixels</h1>
-      <p class="page-subtitle">Through my lens: cities, streets & journeys</p>
-    </header>
-    
-    <section class="post-grid">
-      {posts.map((post) => (
-        <a href={`/post/${post.slug.current}`} class="post-card">
-          {post.mainImage && (
-            <div class="card-image-container">
-              <img 
-                src={urlForImage(post.mainImage).width(600).height(400).fit('crop').quality(80).url()} 
-                alt={post.mainImage.alt || ""} 
-                class="card-image"
-              />
-            </div>
-          )}
-          <div class="card-content">
-            <h3 class="card-title">{post.title}</h3>
-          </div>
-        </a>
-      ))}
+<Layout title="Urban Pixels - Discover the world through my lens">
+  <main class="landing-page">
+    <!-- Hero Section -->
+    <section class="hero-section" style={`background-image: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)), url(${heroPhoto ? urlForImage(heroPhoto.image).width(1800).quality(90).url() : '/placeholder.jpg'});`}>
+      <div class="hero-content">
+        <h1 class="hero-headline">Urban Pixels</h1>
+        <p class="hero-subheadline">Discover the world through my lens. Street, City & Nature Photography.</p>
+        <a href="/photos" class="hero-cta">Explore Gallery</a>
+      </div>
     </section>
+
+    <!-- Featured Works Section -->
+    <section class="featured-works">
+      <h2 class="section-headline">Featured Works</h2>
+      <PhotoGrid client:only="react" filter="featured" />
+    </section>
+
+    <!-- Categories Section -->
+    <section class="categories-section">
+      <h2 class="section-headline">Discover by Category</h2>
+      <div class="category-grid">
+        {(categories || []).map(category => (
+          <a href={`/photos?category=${category.title}`} class="category-tile">
+            <div class="category-image-container">
+              <img src={urlForImage(category.image).width(400).height(400).fit('crop').url()} alt={category.title} class="category-image" />
+            </div>
+            <div class="category-overlay">
+              <h3 class="category-title">{category.title}</h3>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+      <div class="footer-content">
+        <p>&copy; {new Date().getFullYear()} Urban Pixels. All rights reserved.</p>
+        <div class="social-links">
+          <a href="#" class="social-link">Twitter</a>
+          <a href="#" class="social-link">Instagram</a>
+        </div>
+      </div>
+    </footer>
   </main>
 </Layout>
 
 <style>
-  .main-content {
-    max-width: 1600px;
+  :root {
+    --text-dark-blue: #1a202c;
+    --accent-blue: #3B82F6;
+    --light-gray: #F8F9FA;
+    --white: #FFFFFF;
+    --border-color: #e2e8f0;
+  }
+
+  .landing-page {
+    font-family: 'Inter', sans-serif;
+    background-color: var(--white);
+    color: var(--text-dark-blue);
+  }
+
+  .section-headline {
+    text-align: center;
+    font-size: 2.25rem;
+    font-weight: 600;
+    margin-bottom: 3rem;
+  }
+
+  /* Hero Section */
+  .hero-section {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--white);
+    background-size: cover;
+    background-position: center;
+    background-attachment: fixed;
+  }
+
+  .hero-content {
+    max-width: 800px;
+    padding: 2rem;
+  }
+
+  .hero-headline {
+    font-size: 4rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    animation: fadeInDown 1s ease-out;
+  }
+
+  .hero-subheadline {
+    font-size: 1.25rem;
+    font-weight: 300;
+    margin-bottom: 2rem;
+    animation: fadeInUp 1s ease-out 0.5s;
+    animation-fill-mode: backwards;
+  }
+
+  .hero-cta {
+    display: inline-block;
+    padding: 0.8rem 2rem;
+    background-color: var(--accent-blue);
+    color: var(--white);
+    text-decoration: none;
+    font-weight: 500;
+    border-radius: 5px;
+    transition: background-color 0.3s ease;
+    animation: fadeInUp 1s ease-out 1s;
+    animation-fill-mode: backwards;
+  }
+
+  .hero-cta:hover {
+    background-color: #2563EB;
+  }
+
+  /* Featured Works & Categories */
+  .featured-works, .categories-section {
+    padding: 6rem 0;
+  }
+
+  .categories-section {
+    background-color: var(--light-gray);
+  }
+
+  /* Category Grid */
+  .category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    max-width: 1400px;
     margin: 0 auto;
     padding: 0 2.5rem;
   }
 
-  .page-header {
-    padding: 4rem 0;
-    text-align: center;
-    border-bottom: 1px solid var(--border-color);
-    margin-bottom: 4rem;
-  }
-
-  .page-title {
-    font-size: 3rem;
-    font-weight: 700;
-    margin: 0 0 0.5rem 0;
-  }
-
-  .page-subtitle {
-    font-size: 1.2rem;
-    color: var(--text-secondary);
-    margin: 0;
-  }
-
-  .post-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 2rem;
-  }
-
-  .post-card {
-    text-decoration: none;
-    color: var(--text-primary);
-    background-color: #f9f9f9;
-    border: 1px solid var(--border-color);
-    transition: border-color 0.3s ease, transform 0.3s ease;
-  }
-
-  .post-card:hover {
-    border-color: var(--text-primary);
-    transform: translateY(-5px);
-  }
-
-  .card-image-container {
+  .category-tile {
+    position: relative;
     overflow: hidden;
-    aspect-ratio: 16 / 9;
-    background-color: #f0f0f0;
+    border-radius: 8px;
+    aspect-ratio: 1 / 1;
+    text-decoration: none;
+    color: var(--white);
   }
 
-  .card-image {
+  .category-image-container {
+    width: 100%;
+    height: 100%;
+  }
+
+  .category-image {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: transform 0.4s ease;
   }
 
-  .card-content {
-    padding: 1.5rem;
+  .category-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(0, 0, 0, 0.4);
+    transition: background-color 0.4s ease;
   }
 
-  .card-title {
-    font-size: 1.2rem;
-    font-weight: 500;
-    margin: 0;
+  .category-title {
+    font-size: 1.75rem;
+    font-weight: 600;
+    transition: transform 0.4s ease;
   }
 
-  @media (max-width: 600px) {
-    .main-content {
-      padding: 0 1.5rem;
+  .category-tile:hover .category-image {
+    transform: scale(1.05);
+  }
+
+  .category-tile:hover .category-overlay {
+    background-color: rgba(0, 0, 0, 0.6);
+  }
+
+  .category-tile:hover .category-title {
+    transform: scale(1.1);
+  }
+
+  /* Footer */
+  .footer {
+    background-color: var(--text-dark-blue);
+    color: var(--light-gray);
+    padding: 2.5rem;
+    text-align: center;
+  }
+
+  .footer-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .social-links {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .social-link {
+    color: var(--light-gray);
+    text-decoration: none;
+    transition: color 0.3s ease;
+  }
+
+  .social-link:hover {
+    color: var(--accent-blue);
+  }
+
+  /* Keyframe Animations */
+  @keyframes fadeInDown {
+    from {
+      opacity: 0;
+      transform: translateY(-20px);
     }
-    .page-header {
-      padding: 3rem 0;
-      margin-bottom: 3rem;
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes fadeInUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .hero-headline {
+      font-size: 3rem;
+    }
+    .footer-content {
+      flex-direction: column;
+      gap: 1rem;
     }
   }
 </style>

--- a/src/pages/photos.astro
+++ b/src/pages/photos.astro
@@ -1,0 +1,64 @@
+---
+import Layout from '../layouts/Layout.astro';
+import PhotoGrid from '../components/PhotoGrid.tsx';
+
+const { category } = Astro.params;
+const categoryFromQuery = Astro.url.searchParams.get('category');
+---
+
+<Layout title="Photo Gallery - Urban Pixels">
+  <main class="main-content">
+    <header class="page-header">
+      <h1 class="page-title">{categoryFromQuery ? `${categoryFromQuery} Photos` : 'All Photos'}</h1>
+      <p class="page-subtitle">A collection of my work.</p>
+    </header>
+
+    <section>
+      <PhotoGrid client:only="react" category={categoryFromQuery} />
+    </section>
+  </main>
+</Layout>
+
+<style>
+  :root {
+    --text-dark-blue: #1a202c;
+    --light-gray: #F8F9FA;
+  }
+
+  .main-content {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 2.5rem;
+  }
+
+  .page-header {
+    padding: 4rem 0;
+    text-align: center;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 4rem;
+  }
+
+  .page-title {
+    font-size: 3rem;
+    font-weight: 700;
+    margin: 0 0 0.5rem 0;
+    color: var(--text-dark-blue);
+    text-transform: capitalize;
+  }
+
+  .page-subtitle {
+    font-size: 1.2rem;
+    color: #4A5568;
+    margin: 0;
+  }
+
+  @media (max-width: 600px) {
+    .main-content {
+      padding: 0 1.5rem;
+    }
+    .page-header {
+      padding: 3rem 0;
+      margin-bottom: 3rem;
+    }
+  }
+</style>

--- a/src/sanity/schemaTypes/category.ts
+++ b/src/sanity/schemaTypes/category.ts
@@ -13,5 +13,14 @@ export const categoryType = defineType({
       name: "description",
       type: "text",
     }),
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'image',
+      description: 'A representative image for the category.',
+      options: {
+        hotspot: true,
+      },
+    }),
   ],
 });

--- a/src/sanity/schemaTypes/photo.ts
+++ b/src/sanity/schemaTypes/photo.ts
@@ -36,6 +36,19 @@ export const photoType = defineType({
         type: 'text',
     }),
     defineField({
+      name: 'featured',
+      title: 'Featured',
+      type: 'boolean',
+      description: 'Mark this photo to feature it on the homepage.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'categories',
+      title: 'Categories',
+      type: 'array',
+      of: [{ type: 'reference', to: { type: 'category' } }],
+    }),
+    defineField({
       name: "dateTaken",
       type: "datetime",
     }),


### PR DESCRIPTION
This commit introduces a new, modern, and minimalist landing page for the Urban Pixels photography portfolio. The implementation adheres to the specified design requirements, including a hero section, a featured works gallery, a category navigation section, and a clean footer.

This work also involved a significant refactoring to adapt to the project's existing Astro and Sanity architecture, which differed from the initial technical brief.

Key changes:
- Updated the Sanity schema for `photo` and `category` to support the new landing page features.
- Created reusable React components (`PhotoGrid`, `Navigation`) for consistent UI.
- Restructured the site by creating the new landing page at the root and moving the previous index page to `/photos`.
- Resolved a series of build errors related to dependencies and Astro configuration to ensure a successful static build.